### PR TITLE
chore(logging): Remove console.log statements from production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,3 +485,7 @@ In the root directory, run the following
 
 Open chrome dev tools and you should see the box highlighted below appear, click on it to connect to the webpack debugger
 ![GitHub Logo](/docs/inspect.png)
+
+### Logging
+
+The default compilation removes console log statements via `babel-plugin-transform-remove-console`, which is run when `BABEL_ENV=production` (default). To compile a version with logging enabled, run `yarn compile` directly.

--- a/manual/Website1/src/index.jsx
+++ b/manual/Website1/src/index.jsx
@@ -7,6 +7,10 @@ import { corsImport } from "../../../index";
 Promise.all([
   corsImport(`http://localhost:3002/importManifest.js?${Date.now()}`),
   corsImport(`http://localhost:3003/importManifest.js?${Date.now()}`)
-]).then(() => {
-  ReactDOM.render(<App />, document.getElementById("app"));
-});
+])
+  .then(() => {
+    ReactDOM.render(<App />, document.getElementById("app"));
+  })
+  .catch(err => {
+    console.log(err);
+  });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "demo:prod": "yarn && yarn compile && yarn link && yarn demo:one:prod | yarn demo:two:prod",
     "demo:fast": "yarn compile && yarn link && yarn demo:one:fast | yarn demo:two:fast",
     "babel": "yarn compile && cd manual && yarn babel",
-    "prepare": "yarn compile && cd manual && yarn",
+    "prepare": "BABEL_ENV=production yarn compile && cd manual && yarn",
     "semantic-release": "semantic-release",
     "commit": "npx git-cz",
     "encrypt": "node encrypt.js",
@@ -72,6 +72,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
     "babel-loader": "8.0.6",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-watch": "7.0.0",
     "commitizen": "4.0.3",
     "concurrently": "5.1.0",
@@ -117,7 +118,14 @@
     ],
     "plugins": [
       "@babel/plugin-proposal-optional-chaining"
-    ]
+    ],
+    "env": {
+      "production": {
+        "plugins": [
+          "transform-remove-console"
+        ]
+      }
+    }
   },
   "jest": {
     "preset": "jest-puppeteer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,6 +2316,11 @@ babel-plugin-jest-hoist@^25.1.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-preset-jest@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz#d0aebfebb2177a21cde710996fce8486d34f1d33"


### PR DESCRIPTION
The webpack plugin is very verbose. Let's silence it unless explicitly needed. 

## After this change
The default compilation removes console log statements via `babel-plugin-transform-remove-console`, which is run when `BABEL_ENV=production` (default). To compile a version with logging enabled, run `yarn compile` directly.
