### PR TITLE
fix(deps): Adds tapable as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "fs-extra": "^8.1.0",
     "loadjs": "^4.2.0",
     "mem": "^6.0.1",
-    "pkg-up": "^3.1.0"
+    "pkg-up": "^3.1.0",
+    "tapable": "^1.1.3"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
For reference, html-webpack-plugin adds [tapable as a dependency](https://github.com/jantimon/html-webpack-plugin/blob/master/package.json#L59) also.

The irony is, the yarn.lock file isnt touched with this, as it was already in the lockfile because of webpack

fixes #149